### PR TITLE
Develop

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -19,5 +19,5 @@ A clear and concise description of any alternative solutions or features you've 
 **Additional context**
 Add any other context or screenshots about the feature request here.
 
-**Does it fit with Story's design?**
-Tell us why your idea is a good fit for Story in particular, rather than generically being a good idea. Does it align well with Story's goals of simplicity, elegance? Is your idea targeted towards Story's intended audience and use case?
+**Does it fit with Story-Customized's design?**
+Tell us why your idea is a good fit for Story-Customized in particular, rather than generically being a good idea. Does it align well with Story-Customized's goals of simplicity, elegance? Is your idea targeted towards Story-Customized's intended audience and use case?

--- a/README.md
+++ b/README.md
@@ -34,5 +34,7 @@ Story-Customized now adds a handful of new features !
 - Embedded videos with [VideoJS](https://videojs.com/).
 - Keyboard Keys.
 
+Story-Customized has been tested with Hugo v0.145.
+
 Don't take my word for it. Browse through the [demo site](https://story-customized.tchinchow.net/)
 for a complete walkthrough and an introduction to all the features.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,7 +1,7 @@
 # Site settings
 baseurl = "https://example.com/"
 title = "Hugo Story Theme"
-paginate = 5
+pagination.pagerSize = 5
 buildFuture = true
 
 [[menu.social]]
@@ -34,4 +34,6 @@ buildFuture = true
   page = ["HTML"]
   section = ["HTML", "RSS"]
   taxonomy = ["HTML", "RSS"]
-  taxonomyTerm = ["HTML", "RSS"]
+
+[markup.goldmark.renderer]
+  unsafe = true

--- a/exampleSite/content/mermaid.md
+++ b/exampleSite/content/mermaid.md
@@ -42,7 +42,7 @@ Please join me as I walk you through the classical mermaid scripts:
 
 - SequenceDiagram _([read documentation](https://mermaid-js.github.io/mermaid/#/sequenceDiagram?id=sequence-diagrams))_:
   ```go
-  {{</* mermaid */>}}
+  {{</* mermaid "some caption" */>}}
   sequenceDiagram
       participant Alice
       participant Bob
@@ -56,7 +56,7 @@ Please join me as I walk you through the classical mermaid scripts:
       Bob-->John: Jolly good!
   {{</* /mermaid */>}}
   ```
-  {{< mermaid >}}
+  {{< mermaid "some caption" >}}
   sequenceDiagram
       participant Alice
       participant Bob
@@ -69,6 +69,10 @@ Please join me as I walk you through the classical mermaid scripts:
       John->Bob: How about you?
       Bob-->John: Jolly good!
   {{< /mermaid >}}
+
+  > **Note**:  
+  > Please notice how the caption that was provided as a parameter of the Hugo
+  > `shortcode` appears when you hover you mouse over the diagram.
 
 - Flowcharts _([read documentation](https://mermaid-js.github.io/mermaid/#/flowchart?id=flowcharts-basic-syntax))_:
   ```go

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,7 +10,7 @@
 		<link rel="shortcut icon" type="image/png" href="{{ "apple-touch-icon-precomposed.png" | absURL }}">
 		{{ with .Description }}<meta name="description" content="{{. | markdownify }}">{{ end }}
 		{{ with .Keywords }}<meta name="keywords" content="{{.}}">{{ end }}
-		{{ .Hugo.Generator }}
+		{{ hugo.Generator }}
 
 		{{ block "social" . }}
 		{{ end }}
@@ -199,7 +199,7 @@
 			</p>
 		</footer>
 		{{ end }}
-	{{ template "_internal/google_analytics_async.html" . }}
+	{{ template "_internal/google_analytics.html" . }}
 	{{ with .Site.Params.foot }}{{ range . }}
 	{{ . | safeHTML }}{{ end }}{{ end }}
 	</body>

--- a/layouts/_default/index.xml
+++ b/layouts/_default/index.xml
@@ -5,7 +5,7 @@
 		<generator>Hugo -- gohugo.io</generator>
 		<language>en-us</language>
 		<author>{{ .Site.Params.Author }}</author>
-		<rights>Copyright (c) {{ .Site.LastChange.Year }}</rights>
+		<rights>Copyright (c) {{ .Site.Lastmod.Year }}</rights>
 		<updated>{{ .Date }}</updated>
 		{{ range where (where (where .Data.Pages "Section" "ne" "slides") ".Params.skip" "ne" "true") ".Date.Unix" "<" now.Unix }}
 		<item>

--- a/layouts/_default/mailchimp.xml
+++ b/layouts/_default/mailchimp.xml
@@ -5,7 +5,7 @@
 		<generator>Hugo -- gohugo.io</generator>
 		<language>en-us</language>
 		<author>{{ .Site.Params.Author }}</author>
-		<rights>Copyright (c) {{ .Site.LastChange.Year }}</rights>
+		<rights>Copyright (c) {{ .Site.Lastmod.Year }}</rights>
 		<updated>{{ .Date }}</updated>
 		{{ range first 20 (where (where (where .Site.RegularPages "Section" "ne" "slides") ".Params.skip" "ne" "true") ".Date.Unix" "<" now.Unix) }}
 		<item>

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -2,5 +2,7 @@
     <div class="mermaid">
       {{- .Inner -}}
     </div>
-    <figcaption>FIXME</figcaption>
+    {{ if .Get 0 }}
+    <figcaption>{{- .Get 0 -}}</figcaption>
+    {{ end }}
 </figure>


### PR DESCRIPTION
Eventually release the final version of the MermaidJS feature _(see #6)_ which remained available only as a beta for ages and which was not fully functional during all this time.

Fix issues with recent _(as of today at least !)_ versions of Hugo.  
The theme now builds with Hugo version 0.145 which is the latest available version on march 2025.